### PR TITLE
Fix 3 code scanning alerts

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/passwordreset/ResetLinkAssignmentForgotPassword.java
+++ b/src/main/java/org/owasp/webgoat/lessons/passwordreset/ResetLinkAssignmentForgotPassword.java
@@ -23,6 +23,8 @@
 package org.owasp.webgoat.lessons.passwordreset;
 
 import java.util.UUID;
+import java.util.Arrays;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.owasp.webgoat.container.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.container.assignments.AttackResult;
@@ -68,6 +70,9 @@ public class ResetLinkAssignmentForgotPassword extends AssignmentEndpoint {
     String resetLink = UUID.randomUUID().toString();
     ResetLinkAssignment.resetLinks.add(resetLink);
     String host = request.getHeader("host");
+    if (!isValidHost(host)) {
+        return failed(this).output("Invalid host header.").build();
+    }
     if (ResetLinkAssignment.TOM_EMAIL.equals(email)
         && (host.contains(webWolfPort)
             || host.contains(webWolfHost))) { // User indeed changed the host header.
@@ -111,4 +116,8 @@ public class ResetLinkAssignmentForgotPassword extends AssignmentEndpoint {
       // don't care
     }
   }
+    private boolean isValidHost(String host) {
+        List<String> allowedHosts = Arrays.asList(webWolfHost, "another-allowed-host.com");
+        return allowedHosts.contains(host);
+    }
 }

--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -46,7 +46,8 @@ public class SSRFTask2 extends AssignmentEndpoint {
   }
 
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig.pro")) {
+    List<String> authorizedUrls = List.of("http://ifconfig.pro");
+    if (authorizedUrls.contains(url)) {
       String html;
       try (InputStream in = new URL(url).openStream()) {
         html =

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -97,10 +97,8 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    if (webSession.isSecurityEnabled()) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Fixes 3 code scanning alerts:
- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/ghas-bootcamp-WebGoat-test/security/code-scanning/34
To fix the SSRF vulnerability, we need to ensure that the user-provided URL is validated against a list of authorized URLs or restricted to a particular host or URL prefix. This can be achieved by maintaining a list of allowed URLs and checking the user input against this list before proceeding with the request.

  1. Create a list of authorized URLs.
  2. Validate the user-provided URL against this list.
  3. If the URL is not in the list, return a failure result.
  4. If the URL is valid, proceed with the request.
  


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/ghas-bootcamp-WebGoat-test/security/code-scanning/33
To fix the SSRF vulnerability, we need to validate the `host` header before using it to construct the URL. One way to do this is to maintain a list of allowed hosts and check if the provided `host` is in this list. If it is not, we should reject the request or handle it appropriately.

  1. Create a list of allowed hosts.
  2. Check if the `host` header is in the list of allowed hosts.
  3. If the `host` is not allowed, handle the error appropriately (e.g., log the incident, return an error response).
  


- https://github.com/ghas-bootcamp-2024-11-20-cloudlabs100/ghas-bootcamp-WebGoat-test/security/code-scanning/28
To fix the problem, we need to ensure that the XML parser is always configured to prevent XXE attacks, regardless of any conditions. This involves setting the necessary properties on the `XMLInputFactory` to disable external entity resolution and DTDs unconditionally.

  - Modify the `parseXml` method in `CommentsCache` to always set the properties `XMLConstants.ACCESS_EXTERNAL_DTD` and `XMLConstants.ACCESS_EXTERNAL_SCHEMA` to an empty string.
  - This change should be made directly in the `parseXml` method, ensuring that the XML parser is always secure.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._